### PR TITLE
Fix ESM imports on windows

### DIFF
--- a/src/common/connectors.js
+++ b/src/common/connectors.js
@@ -1,12 +1,13 @@
 import path from "path";
 import logger from "../common/logger.js";
+import { pathToFileURL } from "url";
 
 export default async function() {
   // Importing connectors
   logger.debug("--- Setting up Apollon connectors");
   const connectorImports = await Promise.all(
     this.config.$apollon_project_implementations.connectors.map(p =>
-      import(path.join(process.cwd(), p))
+      import(pathToFileURL(path.join(process.cwd(), p)))
     )
   );
 

--- a/src/common/directives.js
+++ b/src/common/directives.js
@@ -1,12 +1,13 @@
 import path from "path";
 import logger from "./logger.js";
+import { pathToFileURL } from "url";
 
 export default async function() {
   logger.debug(`- Compiling directive implementations`);
   let directives = {};
   let asyncBuffer = this.config.$apollon_project_implementations.directives.map(
     filepath => {
-      const impl = import(path.join(process.cwd(), filepath));
+      const impl = import(pathToFileURL(path.join(process.cwd(), filepath)));
       impl.filepath = filepath;
       logger.trace({ filepath }, `-- Included directive implementation`);
       return impl;

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -1,6 +1,7 @@
 import subscriptionsHelper from "../helpers/subscriptions.js";
 import path from "path";
 import logger from "./logger.js";
+import { pathToFileURL } from "url";
 
 export default async function(resolvers) {
   const helpers = {};
@@ -12,7 +13,7 @@ export default async function(resolvers) {
   // Manage custom helpers
   const helperImports = await Promise.all(
     this.config.$apollon_project_implementations.helpers.map(p =>
-      import(path.join(process.cwd(), p))
+      import(pathToFileURL(path.join(process.cwd(), p)))
     )
   );
 

--- a/src/common/injectors.js
+++ b/src/common/injectors.js
@@ -1,5 +1,6 @@
 import path from "path";
 import logger from "./logger.js";
+import { pathToFileURL } from "url";
 
 export default async function() {
   const injectors = [];
@@ -7,7 +8,7 @@ export default async function() {
   logger.debug("--- Setting up injectors");
   const injectorImports = await Promise.all(
     this.config.$apollon_project_implementations.injectors.map(p =>
-      import(path.join(process.cwd(), p))
+      import(pathToFileURL(path.join(process.cwd(), p)))
     )
   );
 

--- a/src/common/middleware.js
+++ b/src/common/middleware.js
@@ -1,16 +1,15 @@
 import path from "path";
 import logger from "./logger.js";
+import { pathToFileURL } from "url";
 
 export default async function() {
   const preContext = this;
 
-  const middlewareWrappers = (
-    await Promise.all(
-      this.config.$apollon_project_implementations.middleware.map(p =>
-        import(path.join(process.cwd(), p))
-      )
+  const middlewareWrappers = (await Promise.all(
+    this.config.$apollon_project_implementations.middleware.map(p =>
+      import(pathToFileURL(path.join(process.cwd(), p)))
     )
-  ).map(e => e.default);
+  )).map(e => e.default);
 
   const futurMiddleware = middlewareWrappers
     .map(wrapper => {

--- a/src/common/plugins.js
+++ b/src/common/plugins.js
@@ -1,6 +1,7 @@
 import path from "path";
 import logger from "./logger.js";
 import fse from "fs-extra";
+import { pathToFileURL } from "url";
 
 export default async function() {
   const plugins = {};
@@ -34,7 +35,7 @@ export default async function() {
 
       try {
         plugin._import = await import(
-          path.join(process.cwd(), plugin._configPath)
+          pathToFileURL(path.join(process.cwd(), plugin._configPath))
         );
       } catch (e) {
         logger.error(e, "--- Could not import plugin");

--- a/src/common/resolvers.js
+++ b/src/common/resolvers.js
@@ -1,6 +1,7 @@
 import path from "path";
 import helperBootstrap from "../common/helpers.js";
 import logger from "../common/logger.js";
+import { pathToFileURL } from "url";
 
 export default async function() {
   /*
@@ -14,7 +15,9 @@ export default async function() {
   );
 
   for (let filepath of this.config.$apollon_project_implementations.types) {
-    const type = (await import(path.join(process.cwd(), filepath))).default;
+    const type = (await import(
+      pathToFileURL(path.join(process.cwd(), filepath))
+    )).default;
     if (type && type.name) {
       resolvers[type.name] = type;
     }
@@ -26,7 +29,8 @@ export default async function() {
   //Setting up resolvers by forwarding schema so that each resolver can add its own implementation
   logger.debug(`- Resolvers`);
   for (let filepath of this.config.$apollon_project_implementations.resolvers) {
-    let imp = (await import(path.join(process.cwd(), filepath))).default;
+    let imp = (await import(pathToFileURL(path.join(process.cwd(), filepath))))
+      .default;
     if (imp) {
       await imp.call(resolvers, this, helpers);
       logger.debug({ filepath }, `-- Delegated to`);

--- a/src/common/subscriptions.js
+++ b/src/common/subscriptions.js
@@ -1,4 +1,5 @@
 import path from "path";
+import { pathToFileURL } from "url";
 
 import apollo_server_express from "apollo-server-express";
 const PubSubDefault = apollo_server_express.PubSub;
@@ -8,9 +9,11 @@ export default async function() {
     this.PubSub = new PubSubDefault();
     return {};
   }
-  const subscriptionsPath = path.join(
-    process.cwd(),
-    this.config.$apollon_project_implementations.subscriptions
+  const subscriptionsPath = pathToFileURL(
+    path.join(
+      process.cwd(),
+      this.config.$apollon_project_implementations.subscriptions
+    )
   );
 
   let customSubscriptions = {};

--- a/src/production.js
+++ b/src/production.js
@@ -1,6 +1,7 @@
 //Third party libraries
 import express from "express";
 import path from "path";
+import { pathToFileURL } from "url";
 
 import pluginsLoader from "./common/plugins.js";
 import subscriptionsLoader from "./common/subscriptions.js";
@@ -29,7 +30,8 @@ export default async function(config) {
   logger.info("- Reading compiled configuration");
   config = Object.assign(
     {},
-    (await import(path.join(process.cwd(), "./config.js"))).default,
+    (await import(pathToFileURL(path.join(process.cwd(), "./config.js"))))
+      .default,
     config
   );
   logger.trace("Final config", config);
@@ -70,9 +72,9 @@ export default async function(config) {
 
   // Compiling typeDefs
   logger.info("- Reading typeDefs (schema/specification");
-  schema.typeDefs = (
-    await import(path.join(process.cwd(), "./schema.js"))
-  ).default;
+  schema.typeDefs = (await import(
+    pathToFileURL(path.join(process.cwd(), "./schema.js"))
+  )).default;
   logger.trace({ typeDefs: schema.typeDefs }, "--- Typedefs");
 
   // Preparing connectors

--- a/src/utils/configBuilder.js
+++ b/src/utils/configBuilder.js
@@ -3,6 +3,7 @@ import fse from "fs-extra";
 import yaml from "js-yaml";
 import glob from "glob";
 import path from "path";
+import { pathToFileURL } from "url";
 
 //Custom
 import logger from "../common/logger.js";
@@ -31,7 +32,7 @@ export default async function() {
   logger.debug("- Preparing config");
   const configs = glob.sync(this.config.sources.config).map(filepath => {
     logger.debug({ filepath }, `-- Importing config file`);
-    return import(path.join(process.cwd(), filepath));
+    return import(pathToFileURL(path.join(process.cwd(), filepath)));
   });
   deepMerge(this.config, ...(await Promise.all(configs)).map(e => e.default));
 


### PR DESCRIPTION
Fix following error on Windows : 
*Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader*

Fix; use [pathToFileUrl](https://nodejs.org/api/url.html#url_url_pathtofileurl_path) with dynamic imports.